### PR TITLE
fixes for linux / intel hd graphics

### DIFF
--- a/src/GBuffer.cpp
+++ b/src/GBuffer.cpp
@@ -11,7 +11,7 @@ void GBuffer::setup(int w, int h) {
 	s.colorFormats.push_back(GL_RGBA); // color + stencil
 	s.colorFormats.push_back(GL_RGBA32F); // vertex coord
 	s.colorFormats.push_back(GL_RGBA32F); // depth + normal
-	s.colorFormats.push_back(GL_RGB32F); // HDR map
+	s.colorFormats.push_back(GL_RGBA32F); // HDR map
 	s.depthStencilAsTexture = true;
 	s.useDepth = true;
 	s.useStencil = true;


### PR DESCRIPTION
Hi, to make your addon work on Debian 9 with a NUC 5i5 (intel HD graphics) i had to change the color format for the HDR map, for avoiding the message:
```
[ error ] ofFbo: FRAMEBUFFER_UNSUPPORTED
```
as this is a message that sometimes happen also to other configuration when using `GL_RGB32F`, so I hope this change could improve compatibility also on other distros or graphic cards.

Thank you for your work on this addon, 
Nicola